### PR TITLE
Fix 1.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,6 @@ dependencies {
 		exclude(module: "gson")
 	}
 
-	// Fabric API
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-
 	// Testing engines
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.2'

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs = -Xmx2G
 
 # Fabric Properties
-# check these on https://fabricmc.net/use
+# check these on https://fabricmc.net/versions.html
 minecraft_version = 1.17
 yarn_mappings = 1.17+build.13
 loader_version = 0.11.6
@@ -11,7 +11,3 @@ loader_version = 0.11.6
 mod_version = 0.4.0
 maven_group = io.minepkg
 archives_base_name = MinepkgCompanion
-
-# Dependencies
-# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-fabric_version = 0.13.1+build.370-1.16

--- a/src/main/java/io/minepkg/companion/mixin/MixinClientQueryResponseS2CPacket.java
+++ b/src/main/java/io/minepkg/companion/mixin/MixinClientQueryResponseS2CPacket.java
@@ -42,7 +42,7 @@ public class MixinClientQueryResponseS2CPacket {
 
     /** Captures the value of packetByteBuf.readString(32767) inside the constructor call */
     @ModifyArg(method = "<init>(Lnet/minecraft/network/PacketByteBuf;)V",
-        at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/util/JsonHelper;deserialize(Lcom/google/gson/Gson;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object;"),
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/util/JsonHelper;deserialize(Lcom/google/gson/Gson;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object;"),
         index = 1
     )
     public String captureJSON(String str) {


### PR DESCRIPTION
I think the last force-push of https://github.com/minepkg/companion-fabric/pull/4 pushed an `INVOKE_ASSIGN` for the `@ModifyArg` when it should have been (and was) `INVOKE`.

`INVOKE` targets the method invocation itself (in this case `JsonHelper.deserialize`) while `INVOKE_ASSIGN` targets the point after the method invocation and variable assignment - which makes no sense when using `@ModifyArg`, thus it crashed with
> @ModifyArg annotation on is targetting a non-method insn

While at it I also removed the fabric API dependency because it's unused and it's linking to a horribly outdated version.